### PR TITLE
Fix for Travis CI errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
   - sudo apt-get update -qq
+  - sudo rm -rf /var/lib/dpkg/lock
   - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.

--- a/vision_layer/vision_commons/package.xml
+++ b/vision_layer/vision_commons/package.xml
@@ -14,17 +14,18 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>OpenCV</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
   <build_export_depend>cv_bridge</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
-  <build_export_depend>OpenCV</build_export_depend>
+  <build_export_depend>dynamic_reconfigure</build_export_depend>
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>dynamic_reconfigure</exec_depend>
 
   <export>
   </export>

--- a/vision_layer/vision_tasks/package.xml
+++ b/vision_layer/vision_tasks/package.xml
@@ -16,20 +16,21 @@
   <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>OpenCV</build_depend>
   <build_depend>vision_commons</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
   <build_export_depend>cv_bridge</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
-  <build_export_depend>OpenCV</build_export_depend>
+  <build_export_depend>dynamic_reconfigure</build_export_depend>
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>dynamic_reconfigure</exec_depend>
 
   <export>
   </export>


### PR DESCRIPTION
According to https://wiki.ros.org/opencv3, 
>Instead of depending on opencv3, you should depend on cv_bridge or image_geometry. Depending on one of those two keys transitively makes you depend on libopencv-dev on Jade and below, or opencv3 on Kinetic and above. 

We are using OpenCV 3, right?